### PR TITLE
Add open graph image support

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -7,6 +7,9 @@ export default defineConfig({
   site: "https://build.withYHR.com",
   integrations: [
     starlight({
+      components: {
+        Head: "./src/components/Head.astro",
+      },
       title: "Build withYHR",
       logo: {
         dark: "./src/assets/logo-dark.svg",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,8 @@
   "dependencies": {
     "@astrojs/starlight": "^0.33.1",
     "astro": "^5.6.1",
+    "astro-og-canvas": "^0.7.0",
+    "canvaskit-wasm": "^0.40.0",
     "sharp": "^0.34.1"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13,6 +13,12 @@ importers:
       astro:
         specifier: ^5.6.1
         version: 5.6.1(rollup@4.40.0)(typescript@5.8.3)(yaml@2.7.1)
+      astro-og-canvas:
+        specifier: ^0.7.0
+        version: 0.7.0(astro@5.6.1(rollup@4.40.0)(typescript@5.8.3)(yaml@2.7.1))
+      canvaskit-wasm:
+        specifier: ^0.40.0
+        version: 0.40.0
       sharp:
         specifier: ^0.34.1
         version: 0.34.1
@@ -1114,6 +1120,12 @@ packages:
         integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==,
       }
 
+  "@webgpu/types@0.1.21":
+    resolution:
+      {
+        integrity: sha512-pUrWq3V5PiSGFLeLxoGqReTZmiiXwY3jRkIG5sLLKjyqNxrwm/04b4nw7LSmGWJcKk59XOM/YRTUwOzo4MMlow==,
+      }
+
   acorn-jsx@5.3.2:
     resolution:
       {
@@ -1211,6 +1223,15 @@ packages:
     peerDependencies:
       astro: ^4.0.0-beta || ^5.0.0-beta || ^3.3.0
 
+  astro-og-canvas@0.7.0:
+    resolution:
+      {
+        integrity: sha512-aamARDNDORPxXlPt+VJakzj4WpNUDjQqUZ06eE82pGMad4aTR/KMm8Ho12qvprgJcM8K7fgSOMg5OHa7KcX0pw==,
+      }
+    engines: { node: ">=18.14.1" }
+    peerDependencies:
+      astro: ^3.0.0 || ^4.0.0 || ^5.0.0
+
   astro@5.6.1:
     resolution:
       {
@@ -1277,6 +1298,18 @@ packages:
         integrity: sha512-8WB3Jcas3swSvjIeA2yvCJ+Miyz5l1ZmB6HFb9R1317dt9LCQoswg/BGrmAmkWVEszSrrg4RwmO46qIm2OEnSA==,
       }
     engines: { node: ">=16" }
+
+  canvaskit-wasm@0.39.1:
+    resolution:
+      {
+        integrity: sha512-Gy3lCmhUdKq+8bvDrs9t8+qf7RvcjuQn+we7vTVVyqgOVO1UVfHpsnBxkTZw+R4ApEJ3D5fKySl9TU11hmjl/A==,
+      }
+
+  canvaskit-wasm@0.40.0:
+    resolution:
+      {
+        integrity: sha512-Od2o+ZmoEw9PBdN/yCGvzfu0WVqlufBPEWNG452wY7E9aT8RBE+ChpZF526doOlg7zumO4iCS+RAeht4P0Gbpw==,
+      }
 
   ccount@2.0.1:
     resolution:
@@ -4142,6 +4175,8 @@ snapshots:
 
   "@ungap/structured-clone@1.3.0": {}
 
+  "@webgpu/types@0.1.21": {}
+
   acorn-jsx@5.3.2(acorn@8.14.1):
     dependencies:
       acorn: 8.14.1
@@ -4181,6 +4216,13 @@ snapshots:
     dependencies:
       astro: 5.6.1(rollup@4.40.0)(typescript@5.8.3)(yaml@2.7.1)
       rehype-expressive-code: 0.40.2
+
+  astro-og-canvas@0.7.0(astro@5.6.1(rollup@4.40.0)(typescript@5.8.3)(yaml@2.7.1)):
+    dependencies:
+      astro: 5.6.1(rollup@4.40.0)(typescript@5.8.3)(yaml@2.7.1)
+      canvaskit-wasm: 0.39.1
+      deterministic-object-hash: 2.0.2
+      entities: 4.5.0
 
   astro@5.6.1(rollup@4.40.0)(typescript@5.8.3)(yaml@2.7.1):
     dependencies:
@@ -4309,6 +4351,14 @@ snapshots:
       fill-range: 7.1.1
 
   camelcase@8.0.0: {}
+
+  canvaskit-wasm@0.39.1:
+    dependencies:
+      "@webgpu/types": 0.1.21
+
+  canvaskit-wasm@0.40.0:
+    dependencies:
+      "@webgpu/types": 0.1.21
 
   ccount@2.0.1: {}
 

--- a/src/components/Head.astro
+++ b/src/components/Head.astro
@@ -1,0 +1,17 @@
+---
+import Default from "@astrojs/starlight/components/Head.astro";
+
+// Get the URL of the generated image for the current page using its ID and
+// append the `.png` file extension.
+const ogImageUrl = new URL(
+  `/og/${Astro.locals.starlightRoute.id || "index"}.png`,
+  Astro.site,
+);
+---
+
+<!-- Render the default <Head/> component. -->
+<Default><slot /></Default>
+
+<!-- Render the <meta/> tags for the Open Graph images. -->
+<meta property='og:image' content={ogImageUrl} />
+<meta name='twitter:image' content={ogImageUrl} />

--- a/src/content/docs/introduction.mdx
+++ b/src/content/docs/introduction.mdx
@@ -1,5 +1,6 @@
 ---
 title: Introduction
+description: Practical guidance for implementing specific features in your SaaS project with Vibe coding
 ---
 
 Vibe coding has been the latest trend. AI tools have made it relatively easy to build a SaaS, but there's still a lot of work to do. Engineers usually know this, but for all the non-technical folks, it's hard to explain. We're here to make it simple for everyone.

--- a/src/images/og/[...slug].ts
+++ b/src/images/og/[...slug].ts
@@ -1,0 +1,29 @@
+import { getCollection } from "astro:content";
+import { OGImageRoute } from "astro-og-canvas";
+
+// Get all entries from the `docs` content collection.
+const entries = await getCollection("docs");
+
+// Map the entry array to an object with the page ID as key and the
+// frontmatter data as value.
+const pages = Object.fromEntries(entries.map(({ data, id }) => [id, { data }]));
+
+export const { getStaticPaths, GET } = OGImageRoute({
+  // Pass down the documentation pages.
+  pages,
+  // Define the name of the parameter used in the endpoint path, here `slug`
+  // as the file is named `[...slug].ts`.
+  param: "slug",
+  // Define a function called for each page to customize the generated image.
+  getImageOptions: (_id, page: (typeof pages)[number]) => {
+    return {
+      // Use the page title and description as the image title and description.
+      title: page.data.title,
+      description: page.data.description,
+      // Customize various colors and add a border.
+      bgGradient: [[24, 24, 27]],
+      border: { color: [63, 63, 70], width: 20 },
+      padding: 120,
+    };
+  },
+});

--- a/src/pages/og/[...slug].ts
+++ b/src/pages/og/[...slug].ts
@@ -7,7 +7,7 @@ const entries = await getCollection("docs");
 // Map the entry array to an object with the page ID as key and the
 // frontmatter data as value.
 const pages = Object.fromEntries(entries.map(({ data, id }) => [id, { data }]));
-
+console.log("lool");
 export const { getStaticPaths, GET } = OGImageRoute({
   // Pass down the documentation pages.
   pages,


### PR DESCRIPTION
I am trying to add open graph image support as described in the docs followed till here
https://hideoo.dev/notes/starlight-og-images#create-the-image-endpoint. But I am getting 

> Entry docs → 404 was not found.
also 
> Also `getStaticPaths()` route pattern was matched, but no matching static path was found for requested path `/og/kk.png`.

I am not sure about the internal working what exactly is happening after routing ? Does someone knows ?